### PR TITLE
feat: sticker migration and save files to disk option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,9 +179,12 @@ cython_debug/
 # PyPI configuration file
 .pypirc
 
-# Cursor  
-#  Cursor is an AI-powered code editor.`.cursorignore` specifies files/directories to 
+# Cursor
+#  Cursor is an AI-powered code editor.`.cursorignore` specifies files/directories to
 #  exclude from AI features like autocomplete and code analysis. Recommended for sensitive data
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
 .cursorindexingignore
+
+# Local migration data
+/migrated-data

--- a/clients/discord_client.py
+++ b/clients/discord_client.py
@@ -5,8 +5,9 @@ This uses the REST API directly with user tokens.
 
 from __future__ import annotations
 
-import aiohttp
 from typing import Any
+
+import aiohttp
 
 
 class DiscordHTTPClient:
@@ -42,7 +43,9 @@ class DiscordHTTPClient:
             if resp.status == 401:
                 raise ValueError("Discord token is invalid or expired")
             if resp.status == 403:
-                raise ValueError("Discord token doesn't have permission for this action")
+                raise ValueError(
+                    "Discord token doesn't have permission for this action"
+                )
             if resp.status >= 400:
                 raise ValueError(f"Discord API error: {resp.status}")
 
@@ -53,7 +56,9 @@ class DiscordHTTPClient:
         user_data = await self.request("GET", "/users/@me")
 
         try:
-            profile_data = await self.request("GET", f"/users/{user_data['id']}/profile")
+            profile_data = await self.request(
+                "GET", f"/users/{user_data['id']}/profile"
+            )
             if "user_profile" in profile_data:
                 user_data.update(profile_data["user_profile"])
         except Exception:
@@ -80,3 +85,7 @@ class DiscordHTTPClient:
     async def get_guild_emojis(self, guild_id: str) -> list[dict[str, Any]]:
         """GET /guilds/{guild_id}/emojis"""
         return await self.request("GET", f"/guilds/{guild_id}/emojis")
+
+    async def get_guild_stickers(self, guild_id: str) -> list[dict[str, Any]]:
+        """GET /guilds/{guild_id}/stickers"""
+        return await self.request("GET", f"/guilds/{guild_id}/stickers")

--- a/main.py
+++ b/main.py
@@ -276,7 +276,7 @@ class MigrationOrchestrator:
         print(f"Migration Options for: {discord_guild['name']}")
         print("=" * 80)
         print("\nWhat would you like to migrate?")
-        print("  [1] Everything (roles, channels, permissions, emojis)")
+        print("  [1] Everything (roles, channels, permissions, emojis, stickers)")
         print("  [2] Custom selection")
         print("  [3] Go back / Cancel")
         print("\nℹ️  Navigation: Enter a number, or press Ctrl+C to go back")
@@ -284,11 +284,14 @@ class MigrationOrchestrator:
         choice = input("\nYour choice: ").strip()
 
         if choice == "1":
+            save_to_disk = input("Save emojis and stickers to disk? (y/n) [default: n]: ").strip().lower() == 'y'
             return {
                 'roles': True,
                 'channels': True,
                 'permissions': True,
-                'emojis': True
+                'emojis': True,
+                'stickers': True,
+                'save_to_disk': save_to_disk
             }
 
         elif choice == "2":
@@ -313,6 +316,12 @@ class MigrationOrchestrator:
 
             migrate_emojis = input("Migrate emojis? (y/n): ").strip().lower() == 'y'
             options['emojis'] = migrate_emojis
+            
+            migrate_stickers = input("Migrate stickers? (y/n): ").strip().lower() == 'y'
+            options['stickers'] = migrate_stickers
+
+            save_to_disk = input("Save emojis and stickers to disk? (y/n): ").strip().lower() == 'y'
+            options['save_to_disk'] = save_to_disk
 
             # Summary
             print("\n" + "=" * 80)
@@ -321,6 +330,8 @@ class MigrationOrchestrator:
             print(f"  • Channels: {'✓' if options['channels'] else '✗'}")
             print(f"  • Channel Permissions: {'✓' if options['permissions'] else '✗'}")
             print(f"  • Emojis: {'✓' if options['emojis'] else '✗'}")
+            print(f"  • Stickers: {'✓' if options['stickers'] else '✗'}")
+            print(f"  • Save to disk: {'✓' if options['save_to_disk'] else '✗'}")
             print("=" * 80)
 
             confirm = input("\nProceed with this configuration? (y/n): ").strip().lower()
@@ -401,7 +412,7 @@ class MigrationOrchestrator:
                             if partial_sync:
                                 print(f"\n✓ Will sync missing parts to: {selected_guild['name']}")
                                 print("  ⚠ WARNING: This matches by exact name!")
-                                print("  - Existing roles/channels/emojis will be SKIPPED")
+                                print("  - Existing roles/channels/emojis/stickers will be SKIPPED")
                                 print("  - Only MISSING items will be added")
                                 print("  - Permissions will be updated for matched channels")
                                 print("  - May result in duplicates if names don't match exactly")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fluxer.py
 aiohttp>=3.8.0
 inquirer>=3.1.0
+apnggif>=0.1.4


### PR DESCRIPTION
I added the requisite sticker requests through a PR which was merged, I tinkered with this yesterday and got it fixed up to support animated stickers with a conversion. The emojis from Discord have a separate animated tag, but for stickers we're only presented with PNGs and APNGs from what I could find, I had to convert the APNG to GIF, which I was able to do so after finding some examples and utilizing a library I found: 

https://github.com/yukinarit/apnggif

On top of that, this PR also adds an option to export the stickers / emojis to a ./migrated-data folder, this is an optional prompt that is prompted whenever you migrate a server similar to the other options. I figured that could be useful to some people for the future especially since the limit for the current public Fluxer instance is only 50 while with Nitro and boosts Discord servers can serve over the Fluxer instance limit, it still exports the data but the normal request is unable to upload the sticker or emotes.